### PR TITLE
Fix catalog URI, which has to be a complete EMF URI.

### DIFF
--- a/bundles/org.palladiosimulator.loadbalancingaction.catalog/plugin.xml
+++ b/bundles/org.palladiosimulator.loadbalancingaction.catalog/plugin.xml
@@ -10,7 +10,7 @@
    <extension
          point="org.palladiosimulator.architecturaltemplates.catalogs">
       <ATCatalog
-            catalogURI="loadbalancingaction.architecturaltemplates#_2eRmoCOzEeSLXszsY50NUw">
+            catalogURI="platform:/plugin/org.palladiosimulator.loadbalancingaction.catalog/loadbalancingaction.architecturaltemplates#_2eRmoCOzEeSLXszsY50NUw">
       </ATCatalog>
    </extension>
 </plugin>


### PR DESCRIPTION
This issue prevents using the new project wizard because of a crash while loading ATs.